### PR TITLE
feat: initialize Play Framework 3.0 backend with Docker service integrations

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,10 @@
+logs
+target
+/.bsp
+/.idea
+/.idea_modules
+/.classpath
+/.project
+/.settings
+/RUNNING_PID
+.DS_Store

--- a/backend/app/controllers/HealthController.scala
+++ b/backend/app/controllers/HealthController.scala
@@ -1,0 +1,18 @@
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+import play.api.libs.json._
+
+@Singleton
+class HealthController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
+
+  def health = Action { implicit request: Request[AnyContent] =>
+    Ok(Json.obj(
+      "status" -> "healthy",
+      "service" -> "pixvault-api",
+      "version" -> "1.0-SNAPSHOT"
+    ))
+  }
+}

--- a/backend/app/controllers/HomeController.scala
+++ b/backend/app/controllers/HomeController.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+
+@Singleton
+class HomeController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
+
+  def index = Action { implicit request: Request[AnyContent] =>
+    Ok("Welcome to PixVault API")
+  }
+}

--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -1,0 +1,27 @@
+name := "pixvault"
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
+
+scalaVersion := "3.7.0"
+
+libraryDependencies ++= Seq(
+  guice,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test,
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.3"
+)
+
+dependencyOverrides ++= Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.14.3",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.14.3"
+)
+
+
+// Adds additional packages into Twirl
+//TwirlKeys.templateImports += "com.example.controllers._"
+
+// Adds additional packages into conf/routes
+// play.sbt.routes.RoutesKeys.routesImport += "com.example.binders._"

--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -10,7 +10,20 @@ libraryDependencies ++= Seq(
   guice,
   "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test,
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.3"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.3",
+  // PostgreSQL and database
+  "org.postgresql" % "postgresql" % "42.7.1",
+  "com.typesafe.slick" %% "slick" % "3.5.0",
+  "com.typesafe.slick" %% "slick-hikaricp" % "3.5.0",
+  "com.typesafe.play" %% "play-json" % "2.10.3",
+  // AWS SDK for S3 (MinIO compatible)
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.590",
+  // Image processing
+  "com.sksamuel.scrimage" % "scrimage-core" % "4.0.32",
+  "com.sksamuel.scrimage" % "scrimage-formats-extra" % "4.0.32",
+  // Database migrations
+  "org.flywaydb" % "flyway-core" % "10.4.1",
+  "org.flywaydb" % "flyway-database-postgresql" % "10.4.1"
 )
 
 dependencyOverrides ++= Seq(

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -2,3 +2,43 @@
 # https://www.playframework.com/documentation/latest/ConfigFile
 
 play.http.secret.key = "changeme"
+
+# Database configuration (PostgreSQL)
+slick.dbs.default.profile = "slick.jdbc.PostgresProfile$"
+slick.dbs.default.db.driver = "org.postgresql.Driver"
+slick.dbs.default.db.url = "jdbc:postgresql://localhost:5432/pixvault"
+slick.dbs.default.db.user = "pixvault"
+slick.dbs.default.db.password = "pixvault"
+slick.dbs.default.db.numThreads = 10
+slick.dbs.default.db.queueSize = 1000
+
+# Flyway configuration for database migrations
+db.default.driver = "org.postgresql.Driver"
+db.default.url = "jdbc:postgresql://localhost:5432/pixvault"
+db.default.username = "pixvault"
+db.default.password = "pixvault"
+
+# S3 configuration (MinIO)
+aws.s3.endpoint = "http://localhost:9090"
+aws.s3.region = "us-east-1"
+aws.s3.bucket = "pixvault"
+aws.s3.accessKey = "minioadmin"
+aws.s3.secretKey = "minioadmin"
+aws.s3.pathStyleAccess = true
+aws.s3.signerOverride = "AWSS3V4SignerType"
+
+# LocalStack configuration (for Lambda)
+aws.lambda.endpoint = "http://localhost:4566"
+aws.lambda.region = "us-east-1"
+
+# Application configuration
+app {
+  upload {
+    maxFileSize = 104857600 # 100MB
+    allowedContentTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"]
+  }
+  
+  processing {
+    thumbnailSizes = [100, 300, 500, 1024]
+  }
+}

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -1,0 +1,4 @@
+# This is the main configuration file for the application.
+# https://www.playframework.com/documentation/latest/ConfigFile
+
+play.http.secret.key = "changeme"

--- a/backend/conf/db/migration/V1__Create_initial_schema.sql
+++ b/backend/conf/db/migration/V1__Create_initial_schema.sql
@@ -1,0 +1,49 @@
+-- Create users table
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create albums table
+CREATE TABLE albums (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create images table
+CREATE TABLE images (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    album_id UUID REFERENCES albums(id) ON DELETE SET NULL,
+    original_key VARCHAR(500) NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    content_type VARCHAR(100) NOT NULL,
+    file_size BIGINT NOT NULL,
+    width INTEGER,
+    height INTEGER,
+    metadata JSONB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create thumbnails table
+CREATE TABLE thumbnails (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    image_id UUID NOT NULL REFERENCES images(id) ON DELETE CASCADE,
+    size INTEGER NOT NULL,
+    s3_key VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create indexes
+CREATE INDEX idx_images_user_id ON images(user_id);
+CREATE INDEX idx_images_album_id ON images(album_id);
+CREATE INDEX idx_thumbnails_image_id ON thumbnails(image_id);
+CREATE INDEX idx_albums_user_id ON albums(user_id);

--- a/backend/conf/logback.xml
+++ b/backend/conf/logback.xml
@@ -1,0 +1,40 @@
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+<configuration>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <withJansi>true</withJansi>
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>
+        %d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+  </root>
+
+</configuration>

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -1,0 +1,13 @@
+# Routes
+# This file defines all application routes (Higher priority routes first)
+# https://www.playframework.com/documentation/latest/ScalaRouting
+# ~~~~
+
+# Health check
+GET     /health                     controllers.HealthController.health
+
+# Home page
+GET     /                           controllers.HomeController.index
+
+# Map static resources from the /public folder to the /assets URL path
+GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/backend/project/build.properties
+++ b/backend/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.0

--- a/backend/project/plugins.sbt
+++ b/backend/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,13 +37,13 @@ services:
 
   minio:
     image: minio/minio:latest
-    command: server /data --console-address ":9001"
+    command: server /data --console-address ":9091"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "9090:9000"
+      - "9091:9091"
     volumes:
       - minio_data:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- Set up Play Framework 3.0 project with Scala 3.7.0
- Configure PostgreSQL database with Slick ORM
- Integrate MinIO for S3-compatible object storage
- Add Flyway for database migrations with initial schema
- Include image processing capabilities with Scrimage
- Adjust MinIO ports to avoid conflict with Play's default port 9000

## Test plan
- [ ] Run `docker-compose up -d` to start all services
- [ ] Run `sbt run` in the backend directory
- [ ] Verify health endpoint responds at http://localhost:9000/health
- [ ] Verify home endpoint responds at http://localhost:9000/
- [ ] Check database migrations are ready to run

🤖 Generated with [Claude Code](https://claude.ai/code)