### PR TITLE
chore: add project documentation and standardize API versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,12 @@ sbt dist                 # Create production distribution
 ### Testing
 ```bash
 npm run test             # Run all tests (frontend + backend)
+npm run test:backend     # Run backend tests only
+
+# Backend test coverage (requires sbt in PATH)
+cd backend
+sbt clean coverage test coverageReport  # Generate test coverage report
+# Coverage report will be in backend/target/scala-3.7.0/scoverage-report/index.html
 ```
 
 ## Architecture
@@ -55,11 +61,18 @@ The backend follows a clean architecture with repository pattern:
 - Token expiration: 24 hours
 - Refresh token support
 
-### API Endpoints (from OpenAPI spec)
-- `/v1/auth/login` - User authentication
-- `/v1/media/*` - Media CRUD operations (not yet implemented)
-- `/v1/storage/*` - Storage management (not yet implemented)
-- `/v1/jobs/*` - Background job monitoring (not yet implemented)
+### API Endpoints
+All API endpoints use `/v1` prefix. See `docs/openapi.yaml` for full specification.
+
+Implemented:
+- `/v1/health` - Health check endpoint
+- `/v1/auth/login` - User authentication  
+- `/v1/auth/refresh` - Refresh access token
+
+Not yet implemented:
+- `/v1/media/*` - Media CRUD operations
+- `/v1/storage/*` - Storage management
+- `/v1/jobs/*` - Background job monitoring
 
 ## Configuration
 
@@ -74,10 +87,13 @@ Copy `.env.example` to `.env` for local development. Key variables:
 `backend/conf/test.conf` disables evolutions and mocks external services for testing.
 
 ## Current Implementation Status
-- ✅ Authentication system (login endpoint, JWT)
+- ✅ Authentication system (login/refresh endpoints, JWT)
 - ✅ User repository with PostgreSQL
 - ✅ Database schema and migrations
 - ✅ Docker Compose development environment
+- ✅ Health check endpoint
+- ✅ API versioning (all endpoints use `/v1` prefix)
+- ✅ Test coverage setup (scoverage plugin)
 - ⏳ Frontend not yet initialized
 - ⏳ Media upload/storage features
 - ⏳ S3/Glacier integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,10 @@ The backend follows a clean architecture with repository pattern:
 - Refresh token support
 
 ### API Endpoints (from OpenAPI spec)
-- `/api/auth/login` - User authentication
-- `/api/media/*` - Media CRUD operations (not yet implemented)
-- `/api/storage/*` - Storage management (not yet implemented)
-- `/api/jobs/*` - Background job monitoring (not yet implemented)
+- `/v1/auth/login` - User authentication
+- `/v1/media/*` - Media CRUD operations (not yet implemented)
+- `/v1/storage/*` - Storage management (not yet implemented)
+- `/v1/jobs/*` - Background job monitoring (not yet implemented)
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,18 @@ Copy `.env.example` to `.env` for local development. Key variables:
 - Database migrations run automatically in dev mode
 - Use Bruno API client in `api-client/` for testing endpoints
 - Check `backend/logs/application.log` for detailed logs
+
+## Git Commit Message Convention
+Follow the Conventional Commits specification:
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation changes
+- `style:` Code style changes (formatting, missing semicolons, etc.)
+- `refactor:` Code refactoring
+- `test:` Adding or updating tests
+- `chore:` Maintenance tasks, dependency updates
+
+Examples:
+- `feat: add user profile image upload`
+- `fix: resolve JWT token expiration issue`
+- `docs: update API documentation for media endpoints`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+PixVault is a low-cost photo and video storage solution using AWS S3 Glacier as an alternative to Google Photos and iCloud. The project uses a monorepo structure with Scala/Play Framework backend and planned React/TypeScript frontend.
+
+## Key Commands
+
+### Development
+```bash
+npm run dev              # Start Docker services + run frontend & backend
+npm run dev:backend      # Run backend only (cd backend && sbt run)
+npm run docker:up        # Start PostgreSQL, LocalStack, and MinIO
+npm run docker:down      # Stop all Docker services
+npm run db:shell         # Connect to PostgreSQL shell
+```
+
+### Backend (Scala/Play)
+```bash
+cd backend
+sbt run                  # Run application on http://localhost:9000
+sbt test                 # Run all tests
+sbt "testOnly *AuthControllerSpec"  # Run specific test
+sbt dist                 # Create production distribution
+```
+
+### Testing
+```bash
+npm run test             # Run all tests (frontend + backend)
+```
+
+## Architecture
+
+### Backend Structure
+The backend follows a clean architecture with repository pattern:
+- **Controllers**: HTTP request handlers in `app/controllers/`
+- **Services**: Business logic (e.g., `PasswordService` for BCrypt, JWT service for tokens)
+- **Repositories**: Data access layer with trait/implementation pattern
+  - `UserRepository` trait defines interface
+  - `SlickUserRepository` provides PostgreSQL implementation
+- **Models**: Domain entities and database table mappings
+- **Dependency Injection**: Guice modules for wiring components
+
+### Database
+- PostgreSQL with UUID primary keys
+- Play Evolutions for schema migrations (auto-applied in dev mode)
+- Evolution files in `backend/conf/evolutions/default/`
+- Test user: `tanaka.yuki@example.com` / `SecurePass123!`
+
+### Authentication
+- JWT-based authentication with HS256 algorithm
+- BCrypt password hashing (10 rounds in production, 4 in tests)
+- Token expiration: 24 hours
+- Refresh token support
+
+### API Endpoints (from OpenAPI spec)
+- `/api/auth/login` - User authentication
+- `/api/media/*` - Media CRUD operations (not yet implemented)
+- `/api/storage/*` - Storage management (not yet implemented)
+- `/api/jobs/*` - Background job monitoring (not yet implemented)
+
+## Configuration
+
+### Environment Variables
+Copy `.env.example` to `.env` for local development. Key variables:
+- `DB_*` - PostgreSQL connection settings
+- `JWT_SECRET` - JWT signing secret
+- `AWS_*` - AWS/LocalStack credentials
+- `S3_BUCKET` - MinIO/S3 bucket name
+
+### Test Configuration
+`backend/conf/test.conf` disables evolutions and mocks external services for testing.
+
+## Current Implementation Status
+- ✅ Authentication system (login endpoint, JWT)
+- ✅ User repository with PostgreSQL
+- ✅ Database schema and migrations
+- ✅ Docker Compose development environment
+- ⏳ Frontend not yet initialized
+- ⏳ Media upload/storage features
+- ⏳ S3/Glacier integration
+- ⏳ Background job processing
+
+## Development Tips
+- The backend uses Play Framework's hot reload - changes are applied automatically
+- Database migrations run automatically in dev mode
+- Use Bruno API client in `api-client/` for testing endpoints
+- Check `backend/logs/application.log` for detailed logs

--- a/api-client/pixvault/Auth/Login.bru
+++ b/api-client/pixvault/Auth/Login.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/api/auth/login
+  url: {{baseUrl}}/v1/auth/login
   body: json
   auth: none
 }

--- a/api-client/pixvault/Auth/Refresh.bru
+++ b/api-client/pixvault/Auth/Refresh.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/api/auth/refresh
+  url: {{baseUrl}}/v1/auth/refresh
   body: json
   auth: none
 }

--- a/api-client/pixvault/System/Health Check.bru
+++ b/api-client/pixvault/System/Health Check.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/health
+  url: {{baseUrl}}/v1/health
   body: none
   auth: none
 }

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -4,11 +4,11 @@
 # ~~~~
 
 # Health check
-GET     /health                     controllers.HealthController.health
+GET     /v1/health                  controllers.HealthController.health
 
 # Authentication
-POST    /api/auth/login             controllers.AuthController.login
-POST    /api/auth/refresh           controllers.AuthController.refresh
+POST    /v1/auth/login              controllers.AuthController.login
+POST    /v1/auth/refresh            controllers.AuthController.refresh
 
 # Home page
 GET     /                           controllers.HomeController.index

--- a/backend/test/controllers/AuthControllerSpec.scala
+++ b/backend/test/controllers/AuthControllerSpec.scala
@@ -67,7 +67,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockJwtService.generateRefreshToken(testUser.id))
         .thenReturn("mock.refresh.token")
 
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "email" -> "test@example.com",
           "password" -> "correctpassword"
@@ -98,7 +98,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockPasswordService.verifyPassword("wrongpassword", passwordHash))
         .thenReturn(false)
 
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "email" -> "test@example.com",
           "password" -> "wrongpassword"
@@ -119,7 +119,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockUserRepository.findByEmailWithPassword("nonexistent@example.com"))
         .thenReturn(Future.successful(None))
 
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "email" -> "nonexistent@example.com",
           "password" -> "anypassword"
@@ -135,7 +135,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
     }
 
     "return 400 Bad Request for invalid JSON format" in {
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "username" -> "test@example.com"  // Missing password field
         ))
@@ -151,7 +151,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
     }
 
     "return 400 Bad Request for missing email field" in {
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "password" -> "password123"
         ))
@@ -166,7 +166,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
     }
 
     "return 400 Bad Request for missing password field" in {
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "email" -> "test@example.com"
         ))
@@ -192,7 +192,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockPasswordService.verifyPassword("SecurePass123!", passwordHash))
         .thenReturn(false) // Password verification fails - no more test user bypass
 
-      val request = FakeRequest(POST, "/api/auth/login")
+      val request = FakeRequest(POST, "/v1/auth/login")
         .withJsonBody(Json.obj(
           "email" -> "tanaka.yuki@example.com",
           "password" -> "SecurePass123!"
@@ -226,7 +226,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockJwtService.generateRefreshToken(userId)).thenReturn(newRefreshToken)
       when(mockUserRepository.findById(userUuid)).thenReturn(Future.successful(Some(testUser)))
 
-      val request = FakeRequest(POST, "/api/auth/refresh")
+      val request = FakeRequest(POST, "/v1/auth/refresh")
         .withJsonBody(Json.obj("refreshToken" -> validRefreshToken))
 
       val result = route(app, request).get
@@ -247,7 +247,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
 
       when(mockJwtService.isRefreshToken(invalidRefreshToken)).thenReturn(false)
 
-      val request = FakeRequest(POST, "/api/auth/refresh")
+      val request = FakeRequest(POST, "/v1/auth/refresh")
         .withJsonBody(Json.obj("refreshToken" -> invalidRefreshToken))
 
       val result = route(app, request).get
@@ -270,7 +270,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockJwtService.extractUserId(validRefreshToken)).thenReturn(Some(userId))
       when(mockUserRepository.findById(userUuid)).thenReturn(Future.successful(None))
 
-      val request = FakeRequest(POST, "/api/auth/refresh")
+      val request = FakeRequest(POST, "/v1/auth/refresh")
         .withJsonBody(Json.obj("refreshToken" -> validRefreshToken))
 
       val result = route(app, request).get
@@ -289,7 +289,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
       when(mockJwtService.isRefreshToken(validRefreshToken)).thenReturn(true)
       when(mockJwtService.extractUserId(validRefreshToken)).thenReturn(None)
 
-      val request = FakeRequest(POST, "/api/auth/refresh")
+      val request = FakeRequest(POST, "/v1/auth/refresh")
         .withJsonBody(Json.obj("refreshToken" -> validRefreshToken))
 
       val result = route(app, request).get
@@ -302,7 +302,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
     }
 
     "return 400 Bad Request for malformed request" in {
-      val request = FakeRequest(POST, "/api/auth/refresh")
+      val request = FakeRequest(POST, "/v1/auth/refresh")
         .withJsonBody(Json.obj("invalidField" -> "value"))
 
       val result = route(app, request).get
@@ -316,7 +316,7 @@ class AuthControllerSpec extends PlaySpec with GuiceOneAppPerTest with MockitoSu
     }
 
     "return 400 Bad Request for missing refreshToken field" in {
-      val request = FakeRequest(POST, "/api/auth/refresh")
+      val request = FakeRequest(POST, "/v1/auth/refresh")
         .withJsonBody(Json.obj())
 
       val result = route(app, request).get

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,13 +6,13 @@ info:
   contact:
     name: PixVault Team
 servers:
-  - url: http://localhost:9000/api
+  - url: http://localhost:9000
     description: Local development server
   - url: https://api.pixvault.app
     description: Production server
 
 paths:
-  /health:
+  /v1/health:
     get:
       summary: Health check endpoint
       tags:
@@ -33,7 +33,7 @@ paths:
                     format: date-time
                     example: "2024-12-15T10:30:45.123Z"
 
-  /auth/login:
+  /v1/auth/login:
     post:
       summary: User login
       tags:
@@ -67,7 +67,7 @@ paths:
           description: Invalid credentials
 
 
-  /auth/refresh:
+  /v1/auth/refresh:
     post:
       summary: Refresh access token
       tags:
@@ -94,7 +94,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuthResponse'
 
-  /media:
+  /v1/media:
     get:
       summary: List media items
       tags:
@@ -286,7 +286,7 @@ paths:
         '413':
           description: File too large
 
-  /media/{id}:
+  /v1/media/{id}:
     get:
       summary: Get media details
       tags:
@@ -382,7 +382,7 @@ paths:
         '404':
           description: Media not found
 
-  /media/{id}/download:
+  /v1/media/{id}/download:
     get:
       summary: Download media file
       tags:
@@ -426,7 +426,7 @@ paths:
         '404':
           description: Media not found
 
-  /media/{id}/archive:
+  /v1/media/{id}/archive:
     post:
       summary: Archive media to Glacier
       tags:
@@ -459,7 +459,7 @@ paths:
         '404':
           description: Media not found
 
-  /media/{id}/restore:
+  /v1/media/{id}/restore:
     post:
       summary: Restore media from Glacier
       tags:
@@ -507,7 +507,7 @@ paths:
           description: Media not found
 
 
-  /storage/stats:
+  /v1/storage/stats:
     get:
       summary: Get storage statistics
       tags:
@@ -522,7 +522,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StorageStats'
 
-  /jobs/{id}:
+  /v1/jobs/{id}:
     get:
       summary: Get job status
       tags:


### PR DESCRIPTION
## Summary
• Add comprehensive project documentation with CLAUDE.md including architecture, commands, and development guidelines
• Refactor API endpoints to use consistent /v1 prefix across all routes, tests, and API client configurations

## Test plan
- [x] Verify all API endpoints work with /v1 prefix
- [x] Confirm Bruno API client requests use updated endpoints
- [x] Test backend functionality remains unchanged
- [x] Validate test coverage commands work as documented

🤖 Generated with [Claude Code](https://claude.ai/code)